### PR TITLE
Test by adding WBEEP

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,14 +36,14 @@ application seemed like an easy way to add version control through Git, but
 the JSON file can also be stored in an external location such as a S3 bucket. I am 
 open to suggestions whether that would be a better option.   
 
-##How to Get Your Project to Show on the Projects Page 
+## How to Get Your Project to Show on the Projects Page 
 Fork the repository. Clone your fork to your local system. 
 
 If you have an interest in previewing your changes, you will need follow the instructions
 in the 'Build Setup' section that follows. If you do not wish to preview your changes, 
 the build step is not required. 
 
-To add your new project:
+### Description of content you could add
 
 The first step here is to decided what parts of the project are important to store and 
 where. The 'portfolio' application is in an Amazon Web Services (AWS) 'bucket', https://s3-us-west-2.amazonaws.com/internal.wma.chs.usgs.gov/makerspace-portfolio/ .
@@ -53,22 +53,22 @@ If a folder does not exist for your project you can create it using the existing
 your guide. Generally speaking, each project folder has three sub-folders, 'final-product',
 'portfolio-images', and 'related-materials'.
 
-final-product folders - hold the main artifacts produced at the end of a period of work. 
+`final-product` folders - hold the main artifacts produced at the end of a period of work. 
 This may be a fully deployed static web application, a file containing an animation, a 
 PDF (portable document format) file, or many other options. The 'final-product' folder may
 contain many folders depending on if the project has resulted in several products in
 separate work intervals. These folders should be denoted by date in the following format mm_dd_yy.
 
-related-materials folders - can be used as a repository for any number of project related
+`related-materials` folders - can be used as a repository for any number of project related
 items that would otherwise be hard to store. Some obvious examples would be Photoshop and 
 Illustrator files required to produce a final product, various notes, scans of hand drawn sketches,
 screen shots, etc; the possibilities are endless. As noted for the 'final-product' folders
 if work was completed during discrete periods, use the date structure described. 
 
-portfolio-images folders - hold the image that for the thumbnail and product information
+`portfolio-images` folders - hold the image that for the thumbnail and product information
 page. More about use of this folder is in the following section.
 
-Adding your product's information to the application 
+### Adding your product's information to the application 
 
 Note-you only need to add your project to the portfolio when a period of work on that product
 has ended. The idea is that once entered into the portfolio, that entry should not need
@@ -95,7 +95,8 @@ Some of the 'values' are in nested arrays that allow the association of multiple
 'periodsOfWork' and 'links'. While the pattern of adding these nested values would be difficult to explain in words, using the existing
 projects as a guide will make adding these values fairly straight forward. 
 
-Adding the Thumbnail image
+### Adding the Thumbnail image
+
 The thumbnail image is the image seen on both the 'products' page and the page with the 
 full description of the projects. This can be a 'screenshot' of something that will visually
 represent the project to 'portfolio' users. The current recommended dimensions of the 
@@ -105,7 +106,7 @@ Once you have the perfect thumbnail image you can upload it to the 'portfolio-im
 project on AWS. You can then grab the URL of the image and replace the value related to 
 "thumbnail" key in the JSON file.
 
-Finishing up
+### Finishing up
 
 Once you have modified the JSON file to include your project's details, all the only step left is 
 to push your work to the GitHub repository and make a pull request. 

--- a/assets/projectDetails.js
+++ b/assets/projectDetails.js
@@ -1,6 +1,48 @@
 export default {
   projects: [
     {
+      "id":"4",
+      "project": "WBEEP - Natural Water Storage Concept Map",
+      "title":"National Integrated Water Availability Assessments-Concept Map",
+      "fundingProviders": ["WBEEP"],
+      "previewText":"Mapbox interactive map of natural water storage as an indicator of water availability ",
+      "descriptionText":"This is a demonstration map and is not for decision making. It shows the latest " +
+        "available daily estimates of natural water storage for approximately 110,000 regions across the " +
+        "lower forty-eight states. Map shading indicates the current natural water storage relative to " +
+        "historical conditions for this time of year.",
+      "thumbnail":"https://s3-us-west-2.amazonaws.com/internal.wma.chs.usgs.gov/makerspace-portfolio/idea-blitz/2020-march/where-is-earths-water/portfolio-images/whereIsWater1300x726.jpg",
+      "currentStatus": "complete",
+      "currentStatusRationale": "This concept map was released publicly Dec 18, 2019 to meet a deadline defined in the Presidential Memo on Water in the West.",
+      "periodsOfWork": [
+          {
+            "workPeriod": { "startDate": "3.14.19", "endDate": "12.18.19"},
+            "contributors": ["Lindsay Platt", "Aaron Briggs", "Alicia Rhoades", "Chip Orr", "David Watkins", "Marty Wernimont", "Megan Hines"],
+          }
+        ],
+      "technologyUsed": ["Mapbox", "Vue", "R"],
+      "keyTerms": ["mapbox", "map", "interactive", "vector tiles"],
+      "keyPoints": "This was the first Makerspace project. We explored and tested new technologies in order to " +
+        "have an interactive map with over 100K features that loaded and performed efficiently for users. Ultimately, " +
+        "we chose to use Mapbox vector tiles as the main technology. The application's framework is built using Vue " +
+        "and the data behind the tiles was generated in R. It set the foundation for a lot of MxS projects - we " +
+        "created the " + ["makerspace-website-base", "https://github.com/usgs-makerspace/makerspace-website-base"] +
+        "repository coming out of this project that initiates a simple Vue project framework.",
+      "links": [
+        ["Website - Production", "https://labs.waterdata.usgs.gov/estimated-availability"],
+        ["Website - Quality Assurance", "http://wbeep-qa-website.s3-website-us-west-2.amazonaws.com/estimated-availability/"],
+        ["Website - Development", "http://wbeep-test-website.s3-website-us-west-2.amazonaws.com/estimated-availability/"],
+        ["Code Repository - Front-end application", "https://github.com/usgs-makerspace/wbeep-viz"],
+        ["Code Repository - data processing", "https://github.com/usgs-makerspace/wbeep-processing"],
+        ["Code Repository - static map image generation", "https://github.com/usgs-makerspace/wbeep-map-images"],
+        ["Outreach - gif animation accompanying initial release", "https://doimspp.sharepoint.com/:i:/r/sites/gs-wma-iidd-makerspace/Shared%20Documents/Project%20-%20WBEEP%20NHM/Availability%20factor%20-%20water%20storage/WBEEP_nov_water_storage_mini_viz/Water_Storage_November_large.gif?csf=1&web=1&e=IZ3rek"],
+        ["Outreach - video animation accompanying initial release", "https://doimspp.sharepoint.com/:v:/r/sites/gs-wma-iidd-makerspace/Shared%20Documents/Project%20-%20WBEEP%20NHM/Availability%20factor%20-%20water%20storage/WBEEP_nov_water_storage_mini_viz/WBEEP_November_Water_Storage_for_instagram.mov?csf=1&web=1&e=k5b64d"],
+        ["Outreach - gif animation of every day of data for Mindi", "https://doimspp.sharepoint.com/:i:/r/sites/gs-wma-iidd-makerspace/Shared%20Documents/Project%20-%20WBEEP%20NHM/Availability%20factor%20-%20water%20storage/WBEEP%20animation%20of%20days%20since%20release/time-lapse-movie/waterstorage_time_lapse_v3_1080x1920.gif?csf=1&web=1&e=9bxDtV"],
+        ["Outreach - video animation of every day of data for Mindi", "https://doimspp.sharepoint.com/:v:/r/sites/gs-wma-iidd-makerspace/Shared%20Documents/Project%20-%20WBEEP%20NHM/Availability%20factor%20-%20water%20storage/WBEEP%20animation%20of%20days%20since%20release/time-lapse-movie/waterstorage_time_lapse_v3_1080x1920.mov?csf=1&web=1&e=7awhYS"]
+        ["Outreach - Joe Nielsen water data blog", "https://waterdata.usgs.gov/blog/25-years-of-water-data-on-the-web/"],
+        ["Outreach - USGS News Item", "https://www.usgs.gov/center-news/new-usgs-iwaas-product-national-integrated-water-availability-assessments-concept-map"]
+      ]
+    },
+    {
       "id":"3",
       "project": "Idea Blitz",
       "title":"Where Is Earth's Water",

--- a/assets/projectDetails.js
+++ b/assets/projectDetails.js
@@ -10,7 +10,7 @@ export default {
         "available daily estimates of natural water storage for approximately 110,000 regions across the " +
         "lower forty-eight states. Map shading indicates the current natural water storage relative to " +
         "historical conditions for this time of year.",
-      "thumbnail":"https://s3-us-west-2.amazonaws.com/internal.wma.chs.usgs.gov/makerspace-portfolio/idea-blitz/2020-march/where-is-earths-water/portfolio-images/whereIsWater1300x726.jpg",
+      "thumbnail":"s3://internal.wma.chs.usgs.gov/makerspace-portfolio/water-budget-estimation-evaluation-project/wbeep-water-storage/portfolio-images/wbeep_still_image.png",
       "currentStatus": "complete",
       "currentStatusRationale": "This concept map was released publicly Dec 18, 2019 to meet a deadline defined in the Presidential Memo on Water in the West.",
       "periodsOfWork": [


### PR DESCRIPTION
Overall thoughts:

I will admit that I was a bit skeptical of creating this portfolio view outside of Sharepoint because I didn't want to have to recreate documentation for things that already exist in Sharepoint. I like the coupling between Teams chat channels and a project's document structure for active projects, but I noticed that this is only intended for projects that are at some kind of "completed" stage (released, shelved, terminated, etc). And for that, I really liked the exercise of summarizing the project outcomes & links concisely while editing the JSON. 

Suggested improvements:

1. It was unclear to me if I should be editing the JSON in the AWS console or in the repo. I thought the repo, but then language under the `Adding your product's information to the application` header says "In the assets folder of the AWS location mentioned earlier, you will find a file called 'projectDetails.js'.". This made me second-guess my choice.
2. We should probably have a set of options for `currentStatus` outlined in the README so that projects use the same language. 
3. Based on the content I was linking for WBEEP in the "links" section, it feels like we should have a section that links to different categories: code, product, and maybe outreach materials (but that can probably go with products). 
4. I would personally prefer to continue to use Sharepoint for storage of almost everything and will likely not use the `related-materials` folder. Rather than a place to store files, I feel like this might be best used to summarize projects and link out to relevant files/content in one place. However, I understand there may be some files that we can't put on Sharepoint and having a place for those to live makes sense. 